### PR TITLE
✨ Feat: 채팅 푸시 알림 구현 (#66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/Users/kimjuchan/Desktop/Hanbat_Market/src/main/resources/hanbatmarketfcm-firebase-adminsdk-nxq2g-9053a4269b.json
+hanbatmarketfcm-firebase-adminsdk-nxq2g-9053a4269b.json
 
 ### STS ###
 .apt_generated
@@ -26,6 +28,8 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 application.yml
+application-test.yml
+src/main/resources/application-test.yml
 src/main/resources/application.yml
 *.yml
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,61 +1,68 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.2'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.2'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'HM'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
-	//채팅 관련
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'io.projectreactor:reactor-core'
-	testImplementation 'io.projectreactor:reactor-test'
-	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
+    //채팅 관련
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.projectreactor:reactor-core'
+    testImplementation 'io.projectreactor:reactor-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	//account 관련
+    //account 관련
 
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
-	testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    //푸시 알림관련
+    // https://mvnrepository.com/artifact/com.google.firebase/firebase-admin
+    implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.2.0'
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
+
+compileJava { options.compilerArgs << '-parameters' }

--- a/spy.log
+++ b/spy.log
@@ -10,3 +10,15 @@
 1710239085549|0|statement|connection 37|url jdbc:h2:mem:323131ed-5aec-474f-8e0e-f312bdd446a4|drop sequence if exists member_seq|drop sequence if exists member_seq
 1710239085549|0|statement|connection 37|url jdbc:h2:mem:323131ed-5aec-474f-8e0e-f312bdd446a4|drop sequence if exists preemption_item_seq|drop sequence if exists preemption_item_seq
 1710239085549|0|statement|connection 37|url jdbc:h2:mem:323131ed-5aec-474f-8e0e-f312bdd446a4|drop sequence if exists trade_seq|drop sequence if exists trade_seq
+1713509434081|1|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists article cascade |drop table if exists article cascade 
+1713509434082|0|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists image_file cascade |drop table if exists image_file cascade 
+1713509434083|0|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists item cascade |drop table if exists item cascade 
+1713509434083|0|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists member cascade |drop table if exists member cascade 
+1713509434083|0|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists preemption_item cascade |drop table if exists preemption_item cascade 
+1713509434084|0|statement|connection 34|url jdbc:h2:mem:testdb|drop table if exists trade cascade |drop table if exists trade cascade 
+1713509434084|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists article_seq|drop sequence if exists article_seq
+1713509434084|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists image_file_seq|drop sequence if exists image_file_seq
+1713509434084|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists item_seq|drop sequence if exists item_seq
+1713509434084|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists member_seq|drop sequence if exists member_seq
+1713509434085|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists preemption_item_seq|drop sequence if exists preemption_item_seq
+1713509434085|0|statement|connection 34|url jdbc:h2:mem:testdb|drop sequence if exists trade_seq|drop sequence if exists trade_seq

--- a/src/main/java/HM/Hanbat_Market/InitDB.java
+++ b/src/main/java/HM/Hanbat_Market/InitDB.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
-@Component
+//@Component
 @RequiredArgsConstructor
 public class InitDB {
 
@@ -46,7 +46,7 @@ public class InitDB {
             ArrayList<ImageFile> imageFiles = new ArrayList<>();
             ImageFile imageFile;
             Article saveArticle;
-            imageFiles.add(new ImageFile("default_image.png", "default_image.png"));
+            imageFiles.add(new ImageFile("default_image2.png", "default_image2.png"));
 
             Member member = Member.createMember("jckim2229@gmail.com", "1",  "jckim2");
             Member member1 = Member.createMember("wncks0303@naver.com", "2",  "wncks0303");
@@ -65,7 +65,7 @@ public class InitDB {
 
             Long articleId = articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
             saveArticle = articleService.findArticle(articleId);
-            imageFile = new ImageFile("default_image.png", "default_image.png");
+            imageFile = new ImageFile("default_image2.png", "default_image2.png");
             ImageFile.createImageFile(saveArticle, imageFile);
 
 
@@ -79,7 +79,7 @@ public class InitDB {
 
             Long articleId1 = articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
             saveArticle = articleService.findArticle(articleId1);
-            imageFile = new ImageFile("default_image.png", "default_image.png");
+            imageFile = new ImageFile("default_image2.png", "default_image2.png");
             ImageFile.createImageFile(saveArticle, imageFile);
 
 
@@ -93,7 +93,7 @@ public class InitDB {
 
             Long articleId2 = articleService.regisArticle(member.getId(), articleCreateDto, itemCreateDto);
             saveArticle = articleService.findArticle(articleId2);
-            imageFile = new ImageFile("default_image.png", "default_image.png");
+            imageFile = new ImageFile("default_image2.png", "default_image2.png");
             ImageFile.createImageFile(saveArticle, imageFile);
 
 
@@ -106,7 +106,7 @@ public class InitDB {
 
             Long articleId3 = articleService.regisArticle(member1.getId(), articleCreateDto, itemCreateDto);
             saveArticle = articleService.findArticle(articleId3);
-            imageFile = new ImageFile("default_image.png", "default_image.png");
+            imageFile = new ImageFile("default_image2.png", "default_image2.png");
             ImageFile.createImageFile(saveArticle, imageFile);
 
             itemCreateDto.setItemName("컴퓨터 개론");
@@ -118,7 +118,7 @@ public class InitDB {
 
             Long articleId4 = articleService.regisArticle(member1.getId(), articleCreateDto, itemCreateDto);
             saveArticle = articleService.findArticle(articleId4);
-            imageFile = new ImageFile("default_image.png", "default_image.png");
+            imageFile = new ImageFile("default_image2.png", "default_image2.png");
             ImageFile.createImageFile(saveArticle, imageFile);
 
             Article article = articleService.findArticle(articleId);

--- a/src/main/java/HM/Hanbat_Market/api/member/LoginControllerApi.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/LoginControllerApi.java
@@ -9,6 +9,7 @@ import HM.Hanbat_Market.exception.member.LoginException;
 import HM.Hanbat_Market.repository.member.MemberRepository;
 import HM.Hanbat_Market.service.account.jwt.JWTUtil;
 import HM.Hanbat_Market.service.member.MemberService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -27,6 +28,7 @@ public class LoginControllerApi {
     private final MemberRepository memberRepository;
     private final JWTUtil jwtUtil;
 
+    @Hidden
     @PostMapping("/login")
     public Result login(@RequestBody LoginRequestDto form, HttpServletRequest request) {
 
@@ -44,6 +46,7 @@ public class LoginControllerApi {
         return new Result<>("ok");
     }
 
+    @Hidden
     @PostMapping("/logout")
     public Result logout(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
@@ -52,4 +55,7 @@ public class LoginControllerApi {
         }
         return new Result<>("ok");
     }
+
+
+
 }

--- a/src/main/java/HM/Hanbat_Market/api/member/MemberControllerApi.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/MemberControllerApi.java
@@ -1,6 +1,7 @@
 package HM.Hanbat_Market.api.member;
 
 import HM.Hanbat_Market.api.Result;
+import HM.Hanbat_Market.api.member.dto.FcmTokenRequest;
 import HM.Hanbat_Market.api.member.dto.MemberRequestDto;
 import HM.Hanbat_Market.api.member.dto.MemberResponseDto;
 import HM.Hanbat_Market.api.member.login.SessionConst;
@@ -27,8 +28,10 @@ public class MemberControllerApi {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final JWTUtil jwtUtil;
+
+    @Hidden
     @PostMapping("/members/new")
-    public Result create(@RequestBody @Valid MemberRequestDto memberRequestDto,
+    public Result create(@RequestBody MemberRequestDto memberRequestDto,
                          HttpServletRequest request) {
 
         String token = jwtUtil.resolveTokenFromRequest(request);
@@ -44,5 +47,15 @@ public class MemberControllerApi {
         memberService.join(member);
 
         return new Result(new MemberResponseDto(member.getMail()));
+    }
+
+    @PostMapping("/fcm/save")
+    public Result saveFcmToken(@RequestBody FcmTokenRequest fcmTokenRequest, HttpServletRequest request) {
+
+        Member member = memberRepository.findByUUID(fcmTokenRequest.getTargetMemberUuid()).get();
+
+        String fcmToken = memberService.updateFcmToken(member.getId(), fcmTokenRequest.getFcmToken());
+
+        return new Result("success save - " + fcmToken);
     }
 }

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/FcmTokenRequest.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/FcmTokenRequest.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+public class FcmTokenRequest {
+    private String targetMemberUuid;
+    private String fcmToken;
+}

--- a/src/main/java/HM/Hanbat_Market/api/trade/TradeControllerApi.java
+++ b/src/main/java/HM/Hanbat_Market/api/trade/TradeControllerApi.java
@@ -4,7 +4,9 @@ import HM.Hanbat_Market.api.Result;
 import HM.Hanbat_Market.api.member.login.SessionConst;
 import HM.Hanbat_Market.api.trade.dto.*;
 import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.domain.entity.Trade;
 import HM.Hanbat_Market.repository.member.MemberRepository;
+import HM.Hanbat_Market.repository.trade.TradeRepository;
 import HM.Hanbat_Market.service.account.jwt.JWTUtil;
 import HM.Hanbat_Market.service.article.ArticleService;
 import HM.Hanbat_Market.service.trade.TradeService;
@@ -22,6 +24,7 @@ public class TradeControllerApi {
 
     private final TradeService tradeService;
     private final MemberRepository memberRepository;
+    private final TradeRepository tradeRepository;
     private final JWTUtil jwtUtil;
 
     @PostMapping("/trade/reservation")
@@ -37,7 +40,8 @@ public class TradeControllerApi {
         Long reservationId = tradeService.reservation(sessionMember, reservationRequestDto.getPurchaserNickname(), reservationRequestDto.getArticleId(), reservationRequestDto.getTransactionAppointmentDateTime(),
                 reservationRequestDto.getReservationPlace());
 
-        return new Result(new ReservationResponseDto(reservationId));
+        Trade trade = tradeRepository.findById(reservationId).get();
+        return new Result(tradeService.mappingReservationResponseDto(trade));
     }
 
     @PostMapping("/trade/complete")

--- a/src/main/java/HM/Hanbat_Market/api/trade/dto/ReservationResponseDto.java
+++ b/src/main/java/HM/Hanbat_Market/api/trade/dto/ReservationResponseDto.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 public class ReservationResponseDto {
 
     private final Long tradeId;
-
+    private final String purchaser;
 }

--- a/src/main/java/HM/Hanbat_Market/chat/Chat.java
+++ b/src/main/java/HM/Hanbat_Market/chat/Chat.java
@@ -14,12 +14,13 @@ public class Chat {
     private String id;
     private String msg;
     private String sender; // 보내는 사람
-    @Hidden
+//    @Hidden
     private String senderNickName;
     private String receiver; // 받는 사람 (귓속말)
-    @Hidden
+//    @Hidden
     private String receiverNickName;
-    private Long roomNum; // 방 번호
+    private String roomNum; // 방 번호
     @Hidden
     private LocalDateTime createdAt;
+    private int fcmOk;
 }

--- a/src/main/java/HM/Hanbat_Market/chat/ChatController.java
+++ b/src/main/java/HM/Hanbat_Market/chat/ChatController.java
@@ -3,8 +3,11 @@ package HM.Hanbat_Market.chat;
 import HM.Hanbat_Market.chat.dto.ChatResponseDto;
 import HM.Hanbat_Market.domain.entity.Member;
 import HM.Hanbat_Market.exception.member.NotExistUuidException;
+import HM.Hanbat_Market.fcm.FcmSendDto;
+import HM.Hanbat_Market.fcm.FcmService;
 import HM.Hanbat_Market.repository.member.MemberRepository;
 import HM.Hanbat_Market.service.member.MemberService;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,14 +33,15 @@ public class ChatController {
     private final ChatRepository chatRepository;
     private final MemberRepository memberRepository;
     private final ChatService chatService;
+    private final FcmService fcmService;
 
     private final ConcurrentHashMap<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Disposable> heartbeats = new ConcurrentHashMap<>();
 
-    // /sender/{sender}/receiver/{receiver} 엔드포인트에서도 하트비트 메시지를 보내도록 수정
     @CrossOrigin
+    @Hidden
     @GetMapping(value = "/sender/{sender}/receiver/{receiver}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<Object> getMsg(@PathVariable String sender, @PathVariable String receiver) {
+    public Flux<Object> getMsg(@PathVariable(value = "receiver") String sender, @PathVariable String receiver) {
         Flux<Chat> chatFlux = chatRepository.mFindBySender(sender, receiver);
         Flux<String> heartbeatFlux = Flux.interval(Duration.ofSeconds(30)) // 30초마다
                 .map(tick -> "heartbeat"); // 하트비트 메시지 생성
@@ -48,7 +52,7 @@ public class ChatController {
     // /chat/roomNum/{roomNum} 엔드포인트에서도 하트비트 메시지를 보내도록 수정
     @CrossOrigin
     @GetMapping(value = "/chat/roomNum/{roomNum}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<Object> findByRoomNum(@PathVariable Integer roomNum) {
+    public Flux<Object> findByRoomNum(@PathVariable(value = "roomNum") String roomNum) {
         SseEmitter sseEmitter = new SseEmitter();
 
         // 연결 이벤트를 보냅니다.
@@ -70,7 +74,7 @@ public class ChatController {
 
 
     @GetMapping(value = "/chat/rooms/{senderId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Flux<ChatResponseDto> getLatestChatsBySender(@PathVariable String senderId) {
+    public Flux<ChatResponseDto> getLatestChatsBySender(@PathVariable(value = "senderId") String senderId) {
         return chatService.findLatestChatsBySender(senderId)
                 .subscribeOn(Schedulers.boundedElastic());
     }
@@ -78,96 +82,33 @@ public class ChatController {
 
     @CrossOrigin
     @PostMapping("/chat")
-    public Mono<Chat> setMsg(@RequestBody Chat chat) {
+    public Mono<Chat> setMsg(@RequestBody Chat chat) throws IOException {
+        Member sender;
+        Member receiver;
+
         try {
+            log.info("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@Receiver");
+            log.info(chat.getReceiver());
+            log.info(chat.getSender());
+            log.info("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@Sender");
             //UUID로 유저 식별
-            Member sender = memberRepository.findByUUID(chat.getSender()).get();
-            Member receiver = memberRepository.findByUUID(chat.getReceiver()).get();
+            sender = memberRepository.findByUUID(chat.getSender()).get();
+            receiver = memberRepository.findByUUID(chat.getReceiver()).get();
 
             chat.setSenderNickName(sender.getNickname());
             chat.setReceiverNickName(receiver.getNickname());
             chat.setCreatedAt(LocalDateTime.now());
 
-        }catch (NoSuchElementException e){
+        } catch (NoSuchElementException e) {
             throw new NotExistUuidException();
         }
-        return chatRepository.save(chat);
-    }
+        Mono<Chat> saveChat = chatRepository.save(chat);
 
-    // 더미 데이터를 보내는 메소드 추가
-    private Flux<Chat> initialHeartbeat() {
-        return Flux.interval(Duration.ofSeconds(30)) // 30초마다
-                .map(ignore -> new Chat()) // 하트비트 메시지 생성
-                .onBackpressureDrop() // 백프레셔로 통해 요소가 버려지지 않도록 설정
-                .doOnError(error -> log.error("하트비트 에러: {}", error)); // 에러 발생 시 로깅
-    }
+        //푸시알림
+        String fcmToken = receiver.getFcmToken();
+        int result = fcmService.sendMessageTo(new FcmSendDto(fcmToken, chat.getSenderNickName(), chat.getMsg()));
+        chat.setFcmOk(result);
 
-//    @CrossOrigin
-//    @GetMapping(value = "/sender/{sender}/receiver/{receiver}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-//    public SseEmitter getMsg(@PathVariable String sender, @PathVariable String receiver) {
-//        String identifier = sender + "-" + receiver;
-//        SseEmitter sseEmitter = createSseEmitter(identifier);
-//
-//        return sseEmitter;
-//    }
-//
-//    @CrossOrigin
-//    @GetMapping(value = "/chat/roomNum/{roomNum}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-//    public SseEmitter findByRoomNum(@PathVariable Integer roomNum) {
-//        String identifier = "room-" + roomNum;
-//        SseEmitter sseEmitter = createSseEmitter(identifier);
-//
-//        // 해당 roomNum에 대한 채팅을 조회하여 Flux로 변환 후 클라이언트에게 전달
-//        chatRepository.mFindByRoomNum(roomNum)
-//                .subscribe(chat -> {
-//                    try {
-//                        sseEmitter.send(chat);
-//                    } catch (IOException e) {
-//                        sseEmitter.completeWithError(e);
-//                    }
-//                });
-//
-//        return sseEmitter;
-//    }
-//
-//    private SseEmitter createSseEmitter(String identifier) {
-//        SseEmitter sseEmitter = new SseEmitter();
-//        sseEmitters.put(identifier, sseEmitter);
-//        sseEmitter.onCompletion(() -> sseEmitters.remove(identifier));
-//        sseEmitter.onTimeout(() -> sseEmitters.remove(identifier));
-//
-//        // 주기적으로 하트비트를 보내는 작업을 수행
-//        Disposable heartbeatDisposable = Flux.interval(Duration.ofSeconds(30)) // 30초마다
-//                .subscribe(tick -> sendHeartbeat(sseEmitter));
-//        heartbeats.put(identifier, heartbeatDisposable);
-//
-//        return sseEmitter;
-//    }
-//
-//    private void sendHeartbeat(SseEmitter sseEmitter) {
-//        try {
-//            sseEmitter.send("heartbeat");
-//        } catch (IOException e) {
-//            // 클라이언트와의 연결이 끊어진 경우 처리
-//            sseEmitter.complete();
-//        }
-//    }
-//
-//    @CrossOrigin
-//    @PostMapping("/chat")
-//    public Mono<Chat> setMsg(@RequestBody Chat chat) {
-//        try {
-//            //UUID로 유저 식별
-//            Member sender = memberRepository.findByUUID(chat.getSender()).get();
-//            Member receiver = memberRepository.findByUUID(chat.getReceiver()).get();
-//
-//            chat.setSenderNickName(sender.getNickname());
-//            chat.setReceiverNickName(receiver.getNickname());
-//            chat.setCreatedAt(LocalDateTime.now());
-//
-//        } catch (NoSuchElementException e) {
-//            throw new NotExistUuidException();
-//        }
-//        return chatRepository.save(chat);
-//    }
+        return saveChat;
+    }
 }

--- a/src/main/java/HM/Hanbat_Market/chat/ChatRepository.java
+++ b/src/main/java/HM/Hanbat_Market/chat/ChatRepository.java
@@ -15,11 +15,11 @@ public interface ChatRepository extends ReactiveMongoRepository<Chat, String> {
 
     @Tailable
     @Query("{ roomNum: ?0 }")
-    Flux<Chat> mFindByRoomNum(Integer roomNum);
+    Flux<Chat> mFindByRoomNum(String roomNum);
 
     @Tailable
-    @Query("{ sender: ?0 }")
-    Flux<Chat> mFindBySender(String sender);
+    @Query("{ $or: [ { sender: ?0, receiver: ?1 }, { sender: ?1, receiver: ?0 } ] }")
+    Flux<Chat> mFindBySenderOrReceiver(String sender, String receiver);
 
     @Aggregation(pipeline = {
             "{ $match: { $or: [ { sender: ?0 }, { receiver: ?0 } ] } }",

--- a/src/main/java/HM/Hanbat_Market/chat/dto/ChatResponseDto.java
+++ b/src/main/java/HM/Hanbat_Market/chat/dto/ChatResponseDto.java
@@ -13,11 +13,11 @@ public class ChatResponseDto {
     private String senderNickname;
     private String receiverNickname;
     private String lastChat;
-    private Long roomNum;
+    private String roomNum;
     private LocalDateTime createdAt;
 
     // Constructor, Getters, and Setters
-    public ChatResponseDto(String senderUuid, String receiverUuid, String senderNickname, String receiverNickname, String lastChat, Long roomNum, LocalDateTime createdAt) {
+    public ChatResponseDto(String senderUuid, String receiverUuid, String senderNickname, String receiverNickname, String lastChat, String roomNum, LocalDateTime createdAt) {
         this.senderUuid = senderUuid;
         this.receiverUuid = receiverUuid;
         this.senderNickname = senderNickname;

--- a/src/main/java/HM/Hanbat_Market/config/FirebaseConfig.java
+++ b/src/main/java/HM/Hanbat_Market/config/FirebaseConfig.java
@@ -1,0 +1,27 @@
+package HM.Hanbat_Market.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init(){
+        try{
+            FileInputStream serviceAccount =
+                    new FileInputStream("src/main/resources/hanbatmarketfcm-firebase-adminsdk-nxq2g-9053a4269b.json");
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/config/SecurityConfig.java
+++ b/src/main/java/HM/Hanbat_Market/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/new", "/api/login", "/api/members/login", "/api/members/logout",
                                 "/css/**", "/assets/**", "/files/**", "/api/images/**", "/*.ico", "/error", "/swagger-ui/**", "/swagger-resources/**",
                                 "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/google79674106d1aa552b.html",
-                        "/mentoring/room/**", "/chat/**", "/chat-front/chat.html", "/chat-front/**").permitAll()
+                                "/mentoring/room/**", "/chat/**", "/chat-front/chat.html", "/chat-front/**", "/api/fcm", "/api/fcm/save").permitAll()
                         .anyRequest().authenticated());
 
         //세션 설정 : STATELESS

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Article.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Article.java
@@ -78,8 +78,10 @@ public class Article {
      * 생성 메서드
      */
     public static Article create(ArticleCreateDto articleCreateDto) {
-        Article article = new Article(articleCreateDto.getTitle(),
-                articleCreateDto.getDescription(), articleCreateDto.getTradingPlace());
+        Article article = new Article(
+                articleCreateDto.getTitle(),
+                articleCreateDto.getDescription(),
+                articleCreateDto.getTradingPlace());
 
         article.regisMember(articleCreateDto.getMember());
         article.regisItem(articleCreateDto.getItem());

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
@@ -32,6 +32,8 @@ public class Member {
 
     private String name;
 
+    private String fcmToken;
+
     @Enumerated(EnumType.STRING) // Enum 타입은 문자열 형태로 저장해야 함
     private Role role;
 
@@ -64,6 +66,11 @@ public class Member {
         this.passwd = passwd;
         this.nickname = nickname;
         this.role = role;
+    }
+
+    public String saveFcmToken(String fcmToken){
+        this.fcmToken = fcmToken;
+        return fcmToken;
     }
 
     public static Member createMember(String mail, String passwd, String nickname) {

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Trade.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Trade.java
@@ -47,8 +47,15 @@ public class Trade {
      * 연관관계 편의 메서드
      */
     private void regisMember(Member member) {
-        this.member = member;
-        member.getTrades().add(this);
+        try {
+            Member beforePurchaser = this.member;
+            beforePurchaser.getTrades().remove(this);
+            this.member = member;
+            member.getTrades().add(this);
+        } catch (NullPointerException e) {
+            this.member = member;
+            member.getTrades().add(this);
+        }
     }
 
     private void regisItem(Item item) {
@@ -76,9 +83,13 @@ public class Trade {
         return this;
     }
 
-    public void cancelStatusToReservation() {
+    public void StatusToReservation(Member purchaser) {
+        this.transactionAppointmentDateTime = setCreatedAt(transactionAppointmentDateTime);
+        this.regisItem(item);
+        this.regisMember(purchaser);
         this.tradeStatus = TradeStatus.RESERVATION;
-        this.item.reservationItemStatus();
+        item.reservationItemStatus();
+        this.reservationPlace = reservationPlace;
     }
 
     public void cancel() {

--- a/src/main/java/HM/Hanbat_Market/exception/GlobalExceptionHandler.java
+++ b/src/main/java/HM/Hanbat_Market/exception/GlobalExceptionHandler.java
@@ -178,5 +178,12 @@ public class GlobalExceptionHandler {
         log.error("[exceptionHandler] ex", e);
         return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
     }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(AlreadyReservationException.class)
+    public ErrorResult AlreadyReservationExceptionHandler(AlreadyReservationException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
 }
 

--- a/src/main/java/HM/Hanbat_Market/exception/trade/AlreadyReservationException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/trade/AlreadyReservationException.java
@@ -1,0 +1,13 @@
+package HM.Hanbat_Market.exception.trade;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class AlreadyReservationException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_ALREADY_RESERVATION";
+    private final static String ERROR_MESSAGE = "이미 예약된 거래입니다.";
+
+    public AlreadyReservationException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/fcm/FcmController.java
+++ b/src/main/java/HM/Hanbat_Market/fcm/FcmController.java
@@ -1,0 +1,38 @@
+package HM.Hanbat_Market.fcm;
+
+import HM.Hanbat_Market.api.Result;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/**
+ * FCM 관리하는 Controller
+ *
+ * @author : lee
+ * @fileName : FcmController
+ * @since : 2/21/24
+ */
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    public FcmController(FcmService fcmService) {
+        this.fcmService = fcmService;
+    }
+
+    @PostMapping("/fcm")
+    public Result pushMessage(@RequestBody @Validated FcmSendDto fcmSendDto) throws IOException {
+        log.debug("[+] 푸시 메시지를 전송합니다. ");
+        int result = fcmService.sendMessageTo(fcmSendDto);
+        return new Result(result);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/fcm/FcmMessageDto.java
+++ b/src/main/java/HM/Hanbat_Market/fcm/FcmMessageDto.java
@@ -1,0 +1,32 @@
+package HM.Hanbat_Market.fcm;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * FCM 전송 Format DTO
+ */
+@Getter
+@Builder
+public class FcmMessageDto {
+    private boolean validateOnly;
+    private FcmMessageDto.Message message;
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private FcmMessageDto.Notification notification;
+        private String token;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/fcm/FcmSendDto.java
+++ b/src/main/java/HM/Hanbat_Market/fcm/FcmSendDto.java
@@ -1,0 +1,24 @@
+package HM.Hanbat_Market.fcm;
+
+import lombok.*;
+
+/**
+ * 모바일에서 전달받은 객체
+ */
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FcmSendDto {
+    private String token;
+
+    private String title;
+
+    private String body;
+
+    @Builder(toBuilder = true)
+    public FcmSendDto(String token, String title, String body) {
+        this.token = token;
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/fcm/FcmService.java
+++ b/src/main/java/HM/Hanbat_Market/fcm/FcmService.java
@@ -1,0 +1,86 @@
+package HM.Hanbat_Market.fcm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * FCM 서비스를 처리하는 구현체
+ */
+@Service
+@Slf4j
+public class FcmService {
+
+    /**
+     * 푸시 메시지 처리를 수행하는 비즈니스 로직
+     */
+    public int sendMessageTo(FcmSendDto fcmSendDto) throws IOException {
+
+        String message = makeMessage(fcmSendDto);
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "Bearer " + getAccessToken());
+
+        log.info(headers.get("Authorization") + "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ push @@@@@@");
+
+        HttpEntity entity = new HttpEntity<>(message, headers);
+
+        String API_URL = "https://fcm.googleapis.com/v1/projects/hanbatmarketfcm/messages:send";
+
+
+        ResponseEntity response = restTemplate.exchange(API_URL, HttpMethod.POST, entity, String.class);
+
+        log.info(response.getStatusCode().toString() + "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ push @@@@@@");
+
+        return response.getStatusCode() == HttpStatus.OK ? 1 : 0;
+    }
+
+    /**
+     * Firebase Admin SDK의 비공개 키를 참조하여 Bearer 토큰을 발급 받습니다.
+     *
+     * @return Bearer token
+     */
+    private String getAccessToken() throws IOException {
+        String firebaseConfigPath = "hanbatmarketfcm-firebase-adminsdk-nxq2g-9053a4269b.json";
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+
+    /**
+     * FCM 전송 정보를 기반으로 메시지를 구성합니다. (Object -> String)
+     *
+     * @param fcmSendDto FcmSendDto
+     * @return String
+     */
+    private String makeMessage(FcmSendDto fcmSendDto) throws JsonProcessingException {
+
+        ObjectMapper om = new ObjectMapper();
+        FcmMessageDto fcmMessageDto = FcmMessageDto.builder()
+                .message(FcmMessageDto.Message.builder()
+                        .token(fcmSendDto.getToken())
+                        .notification(FcmMessageDto.Notification.builder()
+                                .title(fcmSendDto.getTitle())
+                                .body(fcmSendDto.getBody())
+                                .image(null)
+                                .build()
+                        ).build()).validateOnly(false).build();
+
+        return om.writeValueAsString(fcmMessageDto);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/repository/article/JpaArticleRepository.java
+++ b/src/main/java/HM/Hanbat_Market/repository/article/JpaArticleRepository.java
@@ -8,6 +8,7 @@ import HM.Hanbat_Market.repository.article.dto.ArticleSearchDto;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/HM/Hanbat_Market/service/account/jwt/JWTFilter.java
+++ b/src/main/java/HM/Hanbat_Market/service/account/jwt/JWTFilter.java
@@ -36,7 +36,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // 스웨거 관련 경로 리스트
         List<String> swaggerPaths = Arrays.asList("/css/", "/assets/", "/files/", "/api/images/", "/favicon.ico", "/error", "/swagger-ui/", "/swagger-resources/",
-                "/v3/api-docs", "/api-docs", "/swagger-ui.html", "/google79674106d1aa552b.html","/chat","/chat-front/chat.html");
+                "/v3/api-docs", "/api-docs", "/swagger-ui.html", "/google79674106d1aa552b.html","/chat","/chat-front/chat.html", "/api/fcm", "/api/fcm/save");
 
         // 요청된 경로
         String path = request.getRequestURI();

--- a/src/main/java/HM/Hanbat_Market/service/member/MemberService.java
+++ b/src/main/java/HM/Hanbat_Market/service/member/MemberService.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+
     /**
      * 회원가입
      */
@@ -27,6 +28,14 @@ public class MemberService {
         return member.getId();
     }
 
+    @Transactional
+    public String updateFcmToken(Long memberId, String fcmToken) {
+        Member member = memberRepository.findById(memberId).get();
+        String saveFcmToken = member.saveFcmToken(fcmToken);
+        memberRepository.save(member);
+        return saveFcmToken;
+    }
+
     private void validateDuplicateMember(Member member) {
         Optional<Member> findMember = memberRepository.findByNickName((member.getNickname()));
         if (findMember.isPresent()) {
@@ -34,8 +43,7 @@ public class MemberService {
         }
 
         findMember = memberRepository.findByMail((member.getMail()));
-        if (findMember.isPresent())
-        {
+        if (findMember.isPresent()) {
             throw new JoinException();
         }
     }
@@ -55,6 +63,7 @@ public class MemberService {
     public Optional<Member> findOne(String nickName) {
         return memberRepository.findByNickName(nickName);
     }
+
     /**
      * 로그인
      */

--- a/src/test/java/HM/Hanbat_Market/CreateTestEntity.java
+++ b/src/test/java/HM/Hanbat_Market/CreateTestEntity.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class CreateTestEntity {
     public static Member createTestMember2() {
-        String mail = "wncks0303@naver.com";
+        String mail = "wncks030303@naver.com";
         String passwd = "1234";
         String phoneNumber = "010-4321-4321";
         String nickname = "토마스";
@@ -23,10 +23,10 @@ public class CreateTestEntity {
     }
 
     public static Member createTestMember1() {
-        String mail = "jckim229@gmail.com";
+        String mail = "jckim2294@gmail.com";
         String passwd = "1234";
         String phoneNumber = "010-1234-1234";
-        String nickname = "김주찬";
+        String nickname = "김주찬ff";
 
         return Member.createMember(mail, passwd, nickname);
     }

--- a/src/test/java/HM/Hanbat_Market/HanbatMarketApplicationTests.java
+++ b/src/test/java/HM/Hanbat_Market/HanbatMarketApplicationTests.java
@@ -1,9 +1,13 @@
 package HM.Hanbat_Market;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class HanbatMarketApplicationTests {
 
 	@Test

--- a/src/test/java/HM/Hanbat_Market/repository/article/JpaArticleRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/article/JpaArticleRepositoryTest.java
@@ -10,6 +10,8 @@ import HM.Hanbat_Market.repository.member.MemberRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaArticleRepositoryTest {
     @Autowired
     ItemRepository jpaItemRepository;

--- a/src/test/java/HM/Hanbat_Market/repository/item/JpaImageFileRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/item/JpaImageFileRepositoryTest.java
@@ -11,6 +11,8 @@ import HM.Hanbat_Market.repository.member.MemberRepository;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaImageFileRepositoryTest {
     @Autowired
     ArticleRepository jpaArticleRepository;

--- a/src/test/java/HM/Hanbat_Market/repository/item/JpaItemRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/item/JpaItemRepositoryTest.java
@@ -7,6 +7,8 @@ import HM.Hanbat_Market.repository.member.JpaMemberRepository;
 import HM.Hanbat_Market.repository.member.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaItemRepositoryTest {
 
     @Autowired

--- a/src/test/java/HM/Hanbat_Market/repository/item/JpaPreemptionItemRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/item/JpaPreemptionItemRepositoryTest.java
@@ -5,6 +5,8 @@ import HM.Hanbat_Market.repository.article.ArticleRepository;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaPreemptionItemRepositoryTest {
     @Autowired
     ArticleRepository jpaArticleRepository;

--- a/src/test/java/HM/Hanbat_Market/repository/member/JpaMemberRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/member/JpaMemberRepositoryTest.java
@@ -4,6 +4,8 @@ import HM.Hanbat_Market.CreateTestEntity;
 import HM.Hanbat_Market.domain.entity.Member;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaMemberRepositoryTest {
     @Autowired
     MemberRepository jpaMemberRepository;

--- a/src/test/java/HM/Hanbat_Market/repository/trade/JpaTradeRepositoryTest.java
+++ b/src/test/java/HM/Hanbat_Market/repository/trade/JpaTradeRepositoryTest.java
@@ -6,6 +6,8 @@ import HM.Hanbat_Market.repository.item.ItemRepository;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class JpaTradeRepositoryTest {
     @Autowired
     ArticleRepository jpaArticleRepository;

--- a/src/test/java/HM/Hanbat_Market/service/article/ArticleServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/article/ArticleServiceTest.java
@@ -16,6 +16,8 @@ import HM.Hanbat_Market.repository.member.MemberRepository;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class ArticleServiceTest {
     @Autowired
     ArticleService articleService;

--- a/src/test/java/HM/Hanbat_Market/service/member/MemberServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/member/MemberServiceTest.java
@@ -8,6 +8,8 @@ import HM.Hanbat_Market.repository.member.MemberRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class MemberServiceTest {
 
     @Autowired

--- a/src/test/java/HM/Hanbat_Market/service/preemption/PreemptionItemServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/preemption/PreemptionItemServiceTest.java
@@ -7,6 +7,8 @@ import HM.Hanbat_Market.service.article.ArticleService;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class PreemptionItemServiceTest {
     @Autowired
     PreemptionItemService preemptionItemService;

--- a/src/test/java/HM/Hanbat_Market/service/trade/TradeServiceTest.java
+++ b/src/test/java/HM/Hanbat_Market/service/trade/TradeServiceTest.java
@@ -6,6 +6,8 @@ import HM.Hanbat_Market.service.article.ArticleService;
 import HM.Hanbat_Market.service.member.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 class TradeServiceTest {
 
     @Autowired


### PR DESCRIPTION
- FCM 활용 채팅 푸시알림 구현

1. 클라이언트에서 회원가입시 fcm token 등록 -> 서버에서 저장
2. 채팅 시 서버에서 access token 발급 후 receiver uuid 기반 fcm token으로 fcm 서버에 요청
3. fcm에서 인가 후 클라이언트에게 푸시 알림 응답

- Resolvers #66

