### PR TITLE
✨ Feat: 재학생 인증 API 및 프로필 관련 API 구현 (#64, #67)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,11 @@ dependencies {
     implementation group: 'com.google.firebase', name: 'firebase-admin', version: '9.2.0'
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+    //이메일 인증 관련
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    implementation "org.springframework.boot:spring-boot-starter-aop"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/HM/Hanbat_Market/HanbatMarketApplication.java
+++ b/src/main/java/HM/Hanbat_Market/HanbatMarketApplication.java
@@ -1,14 +1,17 @@
 package HM.Hanbat_Market;
 
+import HM.Hanbat_Market.aop.filter.FilterConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
 
 @EnableJpaAuditing //시간 감시
 @SpringBootApplication
 @EnableReactiveMongoRepositories
+@Import(FilterConfig.class)
 public class HanbatMarketApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/HM/Hanbat_Market/aop/LoggingFilter.java
+++ b/src/main/java/HM/Hanbat_Market/aop/LoggingFilter.java
@@ -1,0 +1,38 @@
+package HM.Hanbat_Market.aop;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingFilter.class);
+
+    private final Timer timer;
+    private final QueryCountInspector queryCountInspector;
+
+    public LoggingFilter(final Timer timer, final QueryCountInspector queryCountInspector) {
+        this.timer = timer;
+        this.queryCountInspector = queryCountInspector;
+    }
+
+    @Override
+    protected void doFilterInternal(final HttpServletRequest request,
+                                    final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
+        timer.start();
+
+        filterChain.doFilter(request, response);
+
+        LOGGER.info("요청 : {} {}, {}ms, count: {}",
+                request.getMethod(), request.getRequestURI(), timer.getLatencyMillis(), queryCountInspector.getCount());
+        queryCountInspector.clear();
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/aop/QueryCountInspector.java
+++ b/src/main/java/HM/Hanbat_Market/aop/QueryCountInspector.java
@@ -1,0 +1,38 @@
+package HM.Hanbat_Market.aop;
+
+import static java.util.Objects.isNull;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryCountInspector implements StatementInspector {
+
+    private static final ThreadLocal<Integer> COUNTER = new ThreadLocal<>();
+
+    @Override
+    public String inspect(final String sql) {
+        final Integer currentCount = COUNTER.get();
+
+        if (isNull(currentCount)) {
+            COUNTER.set(1);
+            return sql;
+        }
+
+        COUNTER.set(currentCount + 1);
+        return sql;
+    }
+
+    public int getCount() {
+        final Integer count = COUNTER.get();
+
+        if (isNull(count)) {
+            return 0;
+        }
+        return count;
+    }
+
+    public void clear() {
+        COUNTER.remove();
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/aop/TimeTrace.java
+++ b/src/main/java/HM/Hanbat_Market/aop/TimeTrace.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TimeTrace {
+}

--- a/src/main/java/HM/Hanbat_Market/aop/TimeTraceAspect.java
+++ b/src/main/java/HM/Hanbat_Market/aop/TimeTraceAspect.java
@@ -1,0 +1,35 @@
+package HM.Hanbat_Market.aop;
+
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Log4j2
+@Component
+@Aspect
+public class TimeTraceAspect {
+
+    // @Pointcut("execution(* com.example.demo.repository..*(..))")
+    @Pointcut("@annotation(HM.Hanbat_Market.aop.TimeTrace)")
+    private void timeTracePointcut() {
+    }
+
+    @Around("timeTracePointcut()")
+    public Object traceTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        StopWatch stopWatch = new StopWatch();
+
+        try {
+            stopWatch.start();
+            return joinPoint.proceed(); // 실제 타겟 호출
+        } finally {
+            stopWatch.stop();
+            log.debug("{} - Total time = {}s",
+                    joinPoint.getSignature().toShortString(),
+                    stopWatch.getTotalTimeSeconds());
+        }
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/aop/Timer.java
+++ b/src/main/java/HM/Hanbat_Market/aop/Timer.java
@@ -1,0 +1,20 @@
+package HM.Hanbat_Market.aop;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Timer {
+
+    private static final ThreadLocal<Long> THREAD_LOCAL = new ThreadLocal<>();
+
+    public void start() {
+        THREAD_LOCAL.set(System.currentTimeMillis());
+    }
+
+    public long getLatencyMillis() {
+        final long latencyMillis = System.currentTimeMillis() - THREAD_LOCAL.get();
+        THREAD_LOCAL.remove();
+
+        return latencyMillis;
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/aop/filter/FilterConfig.java
+++ b/src/main/java/HM/Hanbat_Market/aop/filter/FilterConfig.java
@@ -1,0 +1,16 @@
+package HM.Hanbat_Market.aop.filter;
+
+import HM.Hanbat_Market.aop.LoggingFilter;
+import HM.Hanbat_Market.aop.QueryCountInspector;
+import HM.Hanbat_Market.aop.Timer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public LoggingFilter loggingFilter(Timer timer,QueryCountInspector queryCountInspector) {
+        return new LoggingFilter(timer, queryCountInspector);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/api/HomeControllerApi.java
+++ b/src/main/java/HM/Hanbat_Market/api/HomeControllerApi.java
@@ -43,8 +43,8 @@ public class HomeControllerApi {
         String mail = jwtUtil.getUsername(token);
         Member sessionMember = null;
         try {
-             sessionMember = memberRepository.findByMail(mail).get();
-        }catch (NoSuchElementException e){
+            sessionMember = memberRepository.findByMail(mail).get();
+        } catch (NoSuchElementException e) {
             log.info("첫 로그인");
         }
 

--- a/src/main/java/HM/Hanbat_Market/api/article/FileStore.java
+++ b/src/main/java/HM/Hanbat_Market/api/article/FileStore.java
@@ -2,6 +2,7 @@ package HM.Hanbat_Market.api.article;
 
 import HM.Hanbat_Market.domain.entity.ImageFile;
 import HM.Hanbat_Market.exception.article.FileValidityException;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+@Component
 public class FileStore {
 
     //    @Value("${file.dir}")

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileDetailRequest.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileDetailRequest.java
@@ -1,0 +1,8 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import lombok.Data;
+
+@Data
+public class ProfileDetailRequest {
+    String uuid;
+}

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileImageRequest.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileImageRequest.java
@@ -1,0 +1,8 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import lombok.Data;
+
+@Data
+public class ProfileImageRequest {
+    String uuid;
+}

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileImageResponse.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileImageResponse.java
@@ -1,0 +1,13 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@AllArgsConstructor
+public class ProfileImageResponse {
+    private String mail;
+    private String imageFileName;
+}

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileNicknameRequest.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileNicknameRequest.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProfileNicknameRequest {
+    String uuid;
+    String nickName;
+}

--- a/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileResponse.java
+++ b/src/main/java/HM/Hanbat_Market/api/member/dto/ProfileResponse.java
@@ -1,0 +1,12 @@
+package HM.Hanbat_Market.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProfileResponse {
+    String mail;
+    String nickName;
+    String filePath;
+}

--- a/src/main/java/HM/Hanbat_Market/config/HibernateConfiguration.java
+++ b/src/main/java/HM/Hanbat_Market/config/HibernateConfiguration.java
@@ -1,0 +1,22 @@
+package HM.Hanbat_Market.config;
+
+import HM.Hanbat_Market.aop.QueryCountInspector;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HibernateConfiguration {
+
+    private final QueryCountInspector queryCountInspector;
+
+    public HibernateConfiguration(final QueryCountInspector queryCountInspector) {
+        this.queryCountInspector = queryCountInspector;
+    }
+
+    @Bean
+    HibernatePropertiesCustomizer hibernatePropertiesCustomizer() {
+        return properties -> properties.put(AvailableSettings.STATEMENT_INSPECTOR, queryCountInspector);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/config/SecurityConfig.java
+++ b/src/main/java/HM/Hanbat_Market/config/SecurityConfig.java
@@ -67,7 +67,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/members/new", "/api/login", "/api/members/login", "/api/members/logout",
                                 "/css/**", "/assets/**", "/files/**", "/api/images/**", "/*.ico", "/error", "/swagger-ui/**", "/swagger-resources/**",
                                 "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/google79674106d1aa552b.html",
-                                "/mentoring/room/**", "/chat/**", "/chat-front/chat.html", "/chat-front/**", "/api/fcm", "/api/fcm/save").permitAll()
+                                "/mentoring/room/**", "/chat/**", "/chat-front/chat.html", "/chat-front/**", "/api/fcm", "/api/fcm/save"
+                                , "/api/verification", "/api/verification/match", "/api/verification/confirm").permitAll()
                         .anyRequest().authenticated());
 
         //세션 설정 : STATELESS

--- a/src/main/java/HM/Hanbat_Market/config/WebConfig.java
+++ b/src/main/java/HM/Hanbat_Market/config/WebConfig.java
@@ -1,14 +1,9 @@
 package HM.Hanbat_Market.config;
 
-import HM.Hanbat_Market.api.member.login.LoginMemberArgumentResolver;
-import HM.Hanbat_Market.api.member.login.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {

--- a/src/main/java/HM/Hanbat_Market/domain/entity/ImageFile.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/ImageFile.java
@@ -39,13 +39,23 @@ public class ImageFile {
         article.getImageFiles().add(this);
     }
 
-    public void format(){
+    public void format() {
         this.article = null;
+    }
+
+    public void setStoreFileName(String fileName) {
+        this.storeFileName = fileName;
     }
 
     /**
      * 생성 메서드
      */
+
+    public static ImageFile newImageFile() {
+
+        return new ImageFile();
+    }
+
     public static ImageFile createImageFile(Article article, ImageFile imageFile) {
         imageFile.regisArticle(article);
         return imageFile;

--- a/src/main/java/HM/Hanbat_Market/domain/entity/LoginStatus.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/LoginStatus.java
@@ -1,0 +1,5 @@
+package HM.Hanbat_Market.domain.entity;
+
+public enum LoginStatus {
+    LOGIN, LOGOUT;
+}

--- a/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/Member.java
@@ -34,11 +34,20 @@ public class Member {
 
     private String fcmToken;
 
+    private String verificationNumber;
+
+    @Enumerated(EnumType.STRING)
+    private LoginStatus loginStatus;
+
     @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus;
 
     @Enumerated(EnumType.STRING) // Enum 타입은 문자열 형태로 저장해야 함
     private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "file_id")
+    private ImageFile imageFile;
 
     @OneToMany(mappedBy = "member")
     private List<Article> articles = new ArrayList<>();
@@ -69,9 +78,14 @@ public class Member {
         this.passwd = passwd;
         this.nickname = nickname;
         this.role = role;
+        this.memberStatus = MemberStatus.UNVERIFIED;
+        this.verificationNumber = "-1";
+        ImageFile imageFile = new ImageFile();
+        imageFile.setStoreFileName("profile.png");
+        this.setImageFile(imageFile);
     }
 
-    public String saveFcmToken(String fcmToken){
+    public String saveFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
         return fcmToken;
     }
@@ -96,16 +110,43 @@ public class Member {
         setMail(mail);
     }
 
-    public void login(){
-        this.memberStatus = MemberStatus.LOGIN;
+    public void login() {
+        this.loginStatus = LoginStatus.LOGIN;
     }
 
-    public void logout(){
-        this.memberStatus = MemberStatus.LOGOUT;
+    public void logout() {
+        this.loginStatus = LoginStatus.LOGOUT;
+    }
+
+    public void verificationSuccess() {
+        this.memberStatus = MemberStatus.VERIFIED;
+    }
+
+    public boolean verification(String number) {
+        if (this.verificationNumber.equals(number)) {
+            return true;
+        }
+        return false;
+    }
+
+    public void setImageFile(ImageFile imageFile) {
+        this.imageFile = imageFile;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void regisVerificationNumber(String number) {
+        this.verificationNumber = number;
     }
 
     public String getRoleKey() {
         return this.role.getKey();
+    }
+
+    public void pp(){
+        this.memberStatus = MemberStatus.UNVERIFIED;
     }
 
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/HM/Hanbat_Market/domain/entity/MemberStatus.java
+++ b/src/main/java/HM/Hanbat_Market/domain/entity/MemberStatus.java
@@ -1,5 +1,5 @@
 package HM.Hanbat_Market.domain.entity;
 
 public enum MemberStatus {
-    LOGIN, LOGOUT;
+    VERIFIED, UNVERIFIED
 }

--- a/src/main/java/HM/Hanbat_Market/exception/GlobalExceptionHandler.java
+++ b/src/main/java/HM/Hanbat_Market/exception/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package HM.Hanbat_Market.exception;
 
-import HM.Hanbat_Market.exception.account.NullTokenException;
-import HM.Hanbat_Market.exception.account.TokenExpiredException;
-import HM.Hanbat_Market.exception.account.TokenNotValidException;
+import HM.Hanbat_Market.exception.account.*;
 import HM.Hanbat_Market.exception.article.FileOutOfRangeException;
 import HM.Hanbat_Market.exception.article.FileValidityException;
 import HM.Hanbat_Market.exception.article.IsDeleteArticleException;
@@ -182,6 +180,41 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(AlreadyReservationException.class)
     public ErrorResult AlreadyReservationExceptionHandler(AlreadyReservationException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(UnverifiedStudentException.class)
+    public ErrorResult UnverifiedStudentExceptionHandler(UnverifiedStudentException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(AlreadyVerifiedStudentException.class)
+    public ErrorResult AlreadyVerifiedExceptionHandler(AlreadyVerifiedStudentException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(FailMailVerificationException.class)
+    public ErrorResult FailMailVerificationExceptionHandler(FailMailVerificationException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NoHanbatMailException.class)
+    public ErrorResult NoHanbatMailExceptionHandler(NoHanbatMailException e) {
+        log.error("[exceptionHandler] ex", e);
+        return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NotMatchingUuidAndRandomNumberException.class)
+    public ErrorResult NotMatchingUuidAndRandomNumberExceptionHandler(NotMatchingUuidAndRandomNumberException e) {
         log.error("[exceptionHandler] ex", e);
         return new ErrorResult(e.getStatus(), e.getErrorCode(), e.getErrorMessage());
     }

--- a/src/main/java/HM/Hanbat_Market/exception/account/AlreadyVerifiedStudentException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/account/AlreadyVerifiedStudentException.java
@@ -1,0 +1,14 @@
+package HM.Hanbat_Market.exception.account;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class AlreadyVerifiedStudentException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_ALREADY_VERIFIED_STUDENT";
+    private final static String ERROR_MESSAGE = "이미 인증된 재학생입니다.";
+
+    public AlreadyVerifiedStudentException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}
+

--- a/src/main/java/HM/Hanbat_Market/exception/account/FailMailVerificationException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/account/FailMailVerificationException.java
@@ -1,0 +1,14 @@
+package HM.Hanbat_Market.exception.account;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class FailMailVerificationException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_WRONG_VERIFICATION_NUMBER";
+    private final static String ERROR_MESSAGE = "인증 번호가 일치하지 않습니다.";
+
+    public FailMailVerificationException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}
+

--- a/src/main/java/HM/Hanbat_Market/exception/account/NoHanbatMailException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/account/NoHanbatMailException.java
@@ -1,0 +1,14 @@
+package HM.Hanbat_Market.exception.account;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class NoHanbatMailException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_WRONG_NO_HANBAT_MAIL";
+    private final static String ERROR_MESSAGE = "한밭대학교 계정이 아닙니다.";
+
+    public NoHanbatMailException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}
+

--- a/src/main/java/HM/Hanbat_Market/exception/account/NotMatchingUuidAndRandomNumberException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/account/NotMatchingUuidAndRandomNumberException.java
@@ -1,0 +1,13 @@
+package HM.Hanbat_Market.exception.account;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class NotMatchingUuidAndRandomNumberException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_NOT_MATCHING_UUID_RANDOM_NUMBER";
+    private final static String ERROR_MESSAGE = "UUID와 인증 번호가 매칭되지 않습니다.";
+
+    public NotMatchingUuidAndRandomNumberException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/exception/account/UnverifiedStudentException.java
+++ b/src/main/java/HM/Hanbat_Market/exception/account/UnverifiedStudentException.java
@@ -1,0 +1,13 @@
+package HM.Hanbat_Market.exception.account;
+
+import HM.Hanbat_Market.exception.ApplicationException;
+
+public class UnverifiedStudentException extends ApplicationException {
+    private final static int STATUS = 400;
+    private final static String ERROR_CODE = "BAD_REQUEST_UNVERIFIED_STUDENT";
+    private final static String ERROR_MESSAGE = "재학생 인증이 필요한 기능입니다.";
+
+    public UnverifiedStudentException() {
+        super(STATUS, ERROR_CODE, ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/service/account/OAuthAttributes.java
+++ b/src/main/java/HM/Hanbat_Market/service/account/OAuthAttributes.java
@@ -1,5 +1,6 @@
 package HM.Hanbat_Market.service.account;
 
+import HM.Hanbat_Market.domain.entity.ImageFile;
 import HM.Hanbat_Market.domain.entity.Member;
 import HM.Hanbat_Market.domain.entity.Role;
 import lombok.Builder;
@@ -54,6 +55,7 @@ public class OAuthAttributes {
 
     // User 엔티티 생성
     public Member toEntity(String oauthPasswd) {
-        return Member.createMember(email, name, oauthPasswd, "임시 닉네임" + email, Role.USER);
+        Member member = Member.createMember(email, name, oauthPasswd, "임시 닉네임" + email, Role.USER);
+        return member;
     }
 }

--- a/src/main/java/HM/Hanbat_Market/service/account/jwt/JWTFilter.java
+++ b/src/main/java/HM/Hanbat_Market/service/account/jwt/JWTFilter.java
@@ -1,12 +1,8 @@
 package HM.Hanbat_Market.service.account.jwt;
 
 import HM.Hanbat_Market.domain.entity.Member;
-import HM.Hanbat_Market.domain.entity.MemberStatus;
+import HM.Hanbat_Market.domain.entity.LoginStatus;
 import HM.Hanbat_Market.domain.entity.Role;
-import HM.Hanbat_Market.exception.account.NullTokenException;
-import HM.Hanbat_Market.exception.account.TokenExpiredException;
-import HM.Hanbat_Market.exception.account.TokenNotValidException;
-import HM.Hanbat_Market.service.account.jwt.JWTUtil;
 import HM.Hanbat_Market.service.member.MemberService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -40,7 +36,8 @@ public class JWTFilter extends OncePerRequestFilter {
 
         // 스웨거 관련 경로 리스트
         List<String> swaggerPaths = Arrays.asList("/css/", "/assets/", "/files/", "/api/images/", "/favicon.ico", "/error", "/swagger-ui/", "/swagger-resources/",
-                "/v3/api-docs", "/api-docs", "/swagger-ui.html", "/google79674106d1aa552b.html", "/chat", "/chat-front/chat.html", "/api/fcm", "/api/fcm/save");
+                "/v3/api-docs", "/api-docs", "/swagger-ui.html", "/google79674106d1aa552b.html", "/chat", "/chat-front/chat.html",
+                "/api/fcm", "/api/fcm/save", "/api/verification", "/api/verification/match", "/api/verification/confirm");
 
         // 요청된 경로
         String path = request.getRequestURI();
@@ -121,7 +118,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         Member findMember = memberService.findByMail(mail).get();
 
-        if (findMember.getMemberStatus() != MemberStatus.LOGIN) {
+        if (findMember.getLoginStatus() != LoginStatus.LOGIN) {
             memberService.login(findMember.getId());
             log.info("@@@@@@@@@@@ login 상태 변경");
         }

--- a/src/main/java/HM/Hanbat_Market/service/article/ArticleService.java
+++ b/src/main/java/HM/Hanbat_Market/service/article/ArticleService.java
@@ -44,7 +44,7 @@ public class ArticleService {
     private final MemberRepository memberRepository;
     private final ImageFileRepository imageFileRepository;
     private final PreemptionItemService preemptionItemService;
-    private final FileStore fileStore = new FileStore();
+    private final FileStore fileStore;
     private final String FILE_URL = APIURL.url;
     private final int IMAGE_MAX_RANGE = 5;
     private final int THUMBNAIL_FILE_INDEX = 0;

--- a/src/main/java/HM/Hanbat_Market/verification/MailService.java
+++ b/src/main/java/HM/Hanbat_Market/verification/MailService.java
@@ -1,0 +1,71 @@
+package HM.Hanbat_Market.verification;
+
+import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import HM.Hanbat_Market.service.APIURL;
+import HM.Hanbat_Market.service.member.MemberService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private static final String senderEmail = APIURL.senderEmail;
+    private static int number;
+
+    public static void createNumber() {
+        number = (int) (Math.random() * (90000)) + 100000;// (int) Math.random() * (최댓값-최소값+1) + 최소값
+    }
+
+    public MimeMessage CreateMail(String mail) {
+        createNumber();
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            message.setRecipients(MimeMessage.RecipientType.TO, InternetAddress.parse(mail));
+            message.setFrom(senderEmail);
+            message.setSubject("[한밭마켓] 재학생 인증을 위한 인증번호 안내");
+
+            String body = "";
+            body += "<div style='font-family: Arial, sans-serif;'>";
+            body += "<div style='border-top: 2px solid #60b9ce; border-right: 1px solid #e7e7e7; border-left: 1px solid #e7e7e7; border-bottom: 1px solid #e7e7e7; width: 670px; margin: 0 auto;'>";
+            body += "<div style='background-color: #ffffff; padding: 40px 30px 0 35px; text-align: center;'>";
+            body += "<h3 style='color: #2daad1; font-size: 25px; text-align: left; width: 352px; word-spacing: -1px; vertical-align: top;'>인증 번호 확인 후<br>이메일 인증을 완료해 주세요.</h3>";
+            body += "</div>";
+            body += "<div style='text-align: center;'>";
+            body += "<table style='text-align: left; font-family: Arial, sans-serif; width: 605px; margin: 0 auto;'>";
+            body += "<tr><td style='color: #555; font-size: 24px; vertical-align: bottom; height: 27px;'>안녕하세요? 한밭마켓입니다.</td></tr>";
+            body += "<tr><td style='font-size: 22px; word-spacing: -1px; height: 30px;'>아래 인증번호를 입력하시고 재학생 인증을 완료해주세요.</td></tr>";
+            body += "</table>";
+            body += "<div style='background-color: #3cbfaf; font-family: Arial, sans-serif; width: 341px; margin: 0 auto;'>";
+            body += "<table style='text-align: center; color: #fff; width: 100%;'>";
+            body += "<tr><td height='98' style='font-size: 41px;'><span>" + number + "</span></td></tr>";
+            body += "</table>";
+            body += "</div>";
+            body += "</div>";
+            body += "</div>";
+            body += "</div>";
+            message.setText(body, "UTF-8", "html");
+
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+
+        return message;
+    }
+
+    public int sendMail(String mail) {
+        MimeMessage message = CreateMail(mail);
+        javaMailSender.send(message);
+
+        return number;
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/verification/VerificationController.java
+++ b/src/main/java/HM/Hanbat_Market/verification/VerificationController.java
@@ -1,0 +1,68 @@
+package HM.Hanbat_Market.verification;
+
+import HM.Hanbat_Market.api.Result;
+import HM.Hanbat_Market.domain.entity.Member;
+import HM.Hanbat_Market.exception.account.NoHanbatMailException;
+import HM.Hanbat_Market.repository.member.MemberRepository;
+import HM.Hanbat_Market.service.member.MemberService;
+import HM.Hanbat_Market.verification.dto.IsVerifiedRequest;
+import HM.Hanbat_Market.verification.dto.MailRequest;
+import HM.Hanbat_Market.verification.dto.MailResponse;
+import HM.Hanbat_Market.verification.dto.VerificationRequest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class VerificationController {
+
+    private final MailService mailService;
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+
+    @ResponseBody
+    @PostMapping("/verification")
+    public Result MailSend(@RequestBody MailRequest mailRequest) {
+        // 이메일 주소 유효성 검사를 위한 정규식 패턴
+        String emailPattern = "^[a-zA-Z0-9._%+-]+@(o365\\.hanbat\\.ac\\.kr|edu\\.hanbat\\.ac\\.kr)$";
+
+        // 입력된 이메일 주소가 패턴과 일치하는지 확인
+        Pattern pattern = Pattern.compile(emailPattern);
+        Matcher matcher = pattern.matcher(mailRequest.getMail());
+        if (!matcher.matches()) {
+            // 유효하지 않은 이메일 형식일 경우 처리
+            throw new NoHanbatMailException();
+        }
+
+        // 이메일 전송 및 인증번호 발급
+        int number = mailService.sendMail(mailRequest.getMail());
+        String num = String.valueOf(number);
+        memberService.regisVerificationNumber(mailRequest.getMemberUuid(), num);
+
+        return new Result<>("success");
+    }
+
+
+    @ResponseBody
+    @PostMapping("/verification/match")
+    public Result matchingNumber(@RequestBody VerificationRequest verificationRequest) {
+
+        memberService.verification(verificationRequest.getMemberUuid(), verificationRequest.getNumber());
+
+        return new Result("success");
+    }
+
+    @ResponseBody
+    @PostMapping("/verification/confirm")
+    public Result isVerifiedStudent(@RequestBody IsVerifiedRequest isVerifiedRequest) {
+
+        if (memberService.isVerifiedStudent(isVerifiedRequest.getMemberUuid())) {
+            return new Result("verified");
+        }
+
+        return new Result("uuid를 올바르게 넣어주세요");
+    }
+}

--- a/src/main/java/HM/Hanbat_Market/verification/dto/IsVerifiedRequest.java
+++ b/src/main/java/HM/Hanbat_Market/verification/dto/IsVerifiedRequest.java
@@ -1,0 +1,10 @@
+package HM.Hanbat_Market.verification.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IsVerifiedRequest {
+    String memberUuid;
+}

--- a/src/main/java/HM/Hanbat_Market/verification/dto/MailRequest.java
+++ b/src/main/java/HM/Hanbat_Market/verification/dto/MailRequest.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.verification.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MailRequest {
+    String mail;
+    String memberUuid;
+}

--- a/src/main/java/HM/Hanbat_Market/verification/dto/MailResponse.java
+++ b/src/main/java/HM/Hanbat_Market/verification/dto/MailResponse.java
@@ -1,0 +1,12 @@
+package HM.Hanbat_Market.verification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MailResponse {
+    String number;
+}

--- a/src/main/java/HM/Hanbat_Market/verification/dto/VerificationRequest.java
+++ b/src/main/java/HM/Hanbat_Market/verification/dto/VerificationRequest.java
@@ -1,0 +1,11 @@
+package HM.Hanbat_Market.verification.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VerificationRequest {
+    String memberUuid;
+    String number;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>#64, #67

## 📝작업 내용

> - 재학생 인증 구현 (API 4개 참고)
   - SMTP 활용 이메일 인증
   - 정규식 활요 이메일 유효성 검증
- 프로필 관련 API 구현 (닉네임 변경 API 포함)